### PR TITLE
fix top page layout

### DIFF
--- a/src/components/checkbox/userPolicyCheckbox.tsx
+++ b/src/components/checkbox/userPolicyCheckbox.tsx
@@ -26,11 +26,12 @@ const UserPolicyCheckBox: FC<{
                 color="primary"
                 style={{
                   color: 'white',
+                  marginTop: '7px',
                 }}
               />
             }
             label={
-              <p style={{ fontSize: '14px', fontWeight: 'bold' }}>
+              <p style={{ fontSize: '13px', fontWeight: 'bold' }}>
                 I agree to SMT
                 <Link
                   target="_blank"


### PR DESCRIPTION
# topページのチェックボックス周りレイアウト修正

27inchモニターで見た場合、チェックボックス周りの文言の位置ズレが気持ち悪かったので修正しました

## 修正前

- チェックボックス後の文言が2行になっている(27inchモニターの場合)
- チェックボックスと文字列の縦位置が少しズレている
<img width="750" alt="image" src="https://user-images.githubusercontent.com/59217420/210615428-d91c61dc-14b2-4648-b536-63e9e39bdc77.png">

## 修正後

<img width="673" alt="image" src="https://user-images.githubusercontent.com/59217420/210615611-82a5a030-1d23-481b-bb4f-2cb92084970c.png">
